### PR TITLE
Improved list-view colors or just colors normalized.

### DIFF
--- a/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroBase.css
+++ b/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroBase.css
@@ -1365,21 +1365,23 @@
 
 .list-view:focused > .virtual-flow > .clipped-container > .sheet > .list-cell:pressed {
     -fx-background-color: cell_pressed_color;
+    -fx-text-fill: cell_pressed_text_color;
 }
 
 .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:selected {
     -fx-background-color: cell_selected_color;
     -fx-background-insets: 0;
-
-    -fx-text-fill: text_color;
+    -fx-text-fill: cell_selected_text_color;
 }
 
 .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:selected:hover {
     -fx-background-color: cell_selected_hover_color;
+    -fx-text-fill: cell_selected_hover_text_color;
 }
 
 .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:selected:hover:pressed {
     -fx-background-color: cell_selected_pressed_color;
+    -fx-text-fill: cell_selected_pressed_text_color;
 }
 
 /*******************************************************************************

--- a/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroDarkTheme.css
+++ b/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroDarkTheme.css
@@ -361,9 +361,14 @@
     cell_hover_color: #515151;
     cell_pressed_color: #3e3e3e;
 
-    cell_selected_color: derive(accent_color, 20%);
-    cell_selected_hover_color: derive(accent_color, 40%);
-    cell_selected_pressed_color: derive(accent_color, 50%);
+    cell_selected_color: accent_color;
+    cell_selected_hover_color: derive(accent_color, 15%);
+    cell_selected_pressed_color: derive(accent_color, 25%);
+
+    cell_pressed_text_color: white;
+    cell_selected_text_color: white;
+    cell_selected_hover_text_color: white;
+    cell_selected_pressed_text_color: white;
 }
 
 /*******************************************************************************

--- a/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroLightTheme.css
+++ b/jmetro/src/main/resources/jfxtras/styles/jmetro8/JMetroLightTheme.css
@@ -346,11 +346,16 @@
     border_color: #111;
 
     cell_hover_color: #dadada;
-    cell_pressed_color: #c2c2c2;
+    cell_pressed_color: #a2a2a2;
 
-    cell_selected_color: derive(accent_color, 90%);
-    cell_selected_hover_color: derive(accent_color, 70%);
-    cell_selected_pressed_color: derive(accent_color, 60%);
+    cell_selected_color: accent_color;
+    cell_selected_hover_color: derive(accent_color, 15%);
+    cell_selected_pressed_color: derive(accent_color, 25%);
+
+    cell_pressed_text_color: white;
+    cell_selected_text_color: white;
+    cell_selected_hover_text_color: white;
+    cell_selected_pressed_text_color: white;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Just normalized list-view colors, with additions more readable text on colors.

I so lazy, therefore `pressed colors` without screenshots :D 

###### After changes

![image](https://user-images.githubusercontent.com/39625750/54225055-e9253f80-450b-11e9-8bfb-72c0b958deff.png)

![image](https://user-images.githubusercontent.com/39625750/54225155-1ffb5580-450c-11e9-9761-06ae628e762c.png)

###### Before changes

![image](https://user-images.githubusercontent.com/39625750/54225308-7799c100-450c-11e9-9972-88d2473667d9.png)

![image](https://user-images.githubusercontent.com/39625750/54225345-8a13fa80-450c-11e9-9e1b-3a76afc4c6ff.png)

@dukke It is possible that my edits may not like it, because I did them the way I like it, if you don’t like the edits, just close the PR :) Ok?