### PR TITLE
ControlsFX is optional, only require it at compile time

### DIFF
--- a/jmetro/build.gradle
+++ b/jmetro/build.gradle
@@ -18,7 +18,7 @@ javafx {
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 dependencies {
-    implementation 'org.controlsfx:controlsfx:11.0.0'
+    compileOnly 'org.controlsfx:controlsfx:11.0.0'
 }
 
 repositories {


### PR DESCRIPTION
This makes it so that programs that use JMetro but don't use ControlsFX don't get ControlsFX in the final build