### PR TITLE
Fixes #193: Slider - Unable to update slider by clicking on the track before the thumb

### DIFF
--- a/jmetro/src/main/java/impl/jfxtras/styles/jmetro/SliderSkin.java
+++ b/jmetro/src/main/java/impl/jfxtras/styles/jmetro/SliderSkin.java
@@ -46,9 +46,9 @@ public class SliderSkin extends javafx.scene.control.skin.SliderSkin {
         track.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnTrack);
         track.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnTrack);
         track.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromTrack);
+
+        fill.setEventDispatcher(track.eventDispatcherProperty().get());
+
         thumb.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnThumb);
         thumb.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnThumb);
         thumb.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromThumb);


### PR DESCRIPTION
This fixes #193 by propagating all the events of the fill down to the track, instead of just calling the same event handler for the popup.