### PR TITLE
Center progress bar dot stop point

### DIFF
--- a/jmetro/src/main/java/impl/jfxtras/styles/jmetro/ProgressBarSkin.java
+++ b/jmetro/src/main/java/impl/jfxtras/styles/jmetro/ProgressBarSkin.java
@@ -109,7 +109,7 @@ public class ProgressBarSkin extends SkinBase<ProgressBar> {
 
     private Transition createAnimationForDot(Region dot, int dotNumber) {
         double controlWidth = getSkinnable().getBoundsInLocal().getWidth();
-        double firstStop = 0.6 * controlWidth;
+        double firstStop = 0.5 * controlWidth;
 
         SequentialTransition sequentialTransition = new SequentialTransition();
 


### PR DESCRIPTION
The point where the dots of a progress bar "stop" for a short moment is now in the center, instead of slighty to the right. This is very noticeable on wide progress bars.